### PR TITLE
Added support for alternative ports

### DIFF
--- a/lib/App/AllKnowingDNS/Config.pm
+++ b/lib/App/AllKnowingDNS/Config.pm
@@ -33,6 +33,12 @@ has 'listen_addresses' => (
     },
 );
 
+has 'port' => (
+    is => 'rw',
+    isa => 'Int',
+    default => 53,
+);
+
 has 'zones' => (
     traits => [ 'Array' ],
     is => 'ro',

--- a/lib/App/AllKnowingDNS/Util.pm
+++ b/lib/App/AllKnowingDNS/Util.pm
@@ -50,13 +50,18 @@ sub parse_config {
         # If we are not currently parsing a zone, only the 'network' keyword is
         # appropriate.
         if (!defined($current_zone) &&
-            !($line =~ /^network/i) && !($line =~ /^listen/i)) {
-            say STDERR qq|all-knowing-dns: CONFIG: Expected 'network' or 'listen' keyword in line "$line"|;
+            !($line =~ /^network/i) && !($line =~ /^listen/i) && !($line =~ /^port/i)) {
+            say STDERR qq|all-knowing-dns: CONFIG: Expected 'network', 'listen' or 'port' keyword in line "$line"|;
             next;
         }
 
         if (my ($address) = ($line =~ /^listen (.*)/i)) {
             $config->add_listen_address(lc $address);
+            next;
+        }
+
+        if (my ($port) = ($line =~ /^port (.*)/i)) {
+            $config->port($port);
             next;
         }
 

--- a/script/all-knowing-dns
+++ b/script/all-knowing-dns
@@ -58,9 +58,9 @@ close($fh);
 my $config = App::AllKnowingDNS::Util::parse_config($input);
 # TODO: sanity check config
 
-# XXX: port configurable? better error message when running without privileges
+# XXX: better error message when running without privileges
 my $ns = Net::DNS::Nameserver->new(
-    LocalPort => 53,
+    LocalPort => $config->port,
     LocalAddr => [ $config->all_listen_addresses ],
     ReplyHandler => sub {
         App::AllKnowingDNS::Handler::reply_handler($config, $querylog, @_)
@@ -123,6 +123,8 @@ The configuration file is wonderfully simple:
     listen 79.140.39.197
     listen 2001:4d88:100e:1::3
     
+    port 53
+    
     # RaumZeitLabor
     network 2001:4d88:100e:ccc0::/64
         resolves to ipv6-%DIGITS%.nutzer.raumzeitlabor.de
@@ -139,7 +141,12 @@ one:
 
 =item B<listen I<address>>
 
-Listens on the given I<address> (IPv4 and IPv6 is supported) on port 53.
+Listens on the given I<address> (IPv4 and IPv6 is supported), by default on
+port 53.
+
+=item B<port I<port>>
+
+Listens on the given I<port>, defaults to 53.
 
 =item B<network I<network>>
 


### PR DESCRIPTION
This allows AllKnowingDNS to run on the same IP address as another DNS server/resolver.