### PR TITLE
Made query handler case-insensitive

### DIFF
--- a/lib/App/AllKnowingDNS/Config.pm
+++ b/lib/App/AllKnowingDNS/Config.pm
@@ -56,7 +56,7 @@ sub add_zone {
 
     my $aaaazone = quotemeta($zone->resolves_to);
     $aaaazone =~ s/\\%DIGITS\\%/([a-z0-9]+)/i;
-    $zone->aaaazone(qr/^$aaaazone$/);
+    $zone->aaaazone(qr/^$aaaazone$/i);
 
     $zone->ptrzone(App::AllKnowingDNS::Util::netmask_to_ptrzone($zone->network));
 
@@ -83,7 +83,7 @@ sub zone_for_ptr {
 
     for my $zone ($self->all_zones) {
         my $suffix = $zone->ptrzone;
-        return $zone if substr($query, -1 * length($suffix)) eq $suffix;
+        return $zone if substr(lc($query), -1 * length($suffix)) eq lc($suffix);
     }
 
     return undef;
@@ -107,7 +107,7 @@ sub zone_for_aaaa {
     my ($self, $query) = @_;
 
     for my $zone ($self->all_zones) {
-        return $zone if $query =~ $zone->aaaazone;
+        return $zone if lc($query) =~ $zone->aaaazone;
     }
 
     return undef;

--- a/lib/App/AllKnowingDNS/Handler.pm
+++ b/lib/App/AllKnowingDNS/Handler.pm
@@ -70,13 +70,13 @@ sub handle_aaaa_query {
 
     my $ttl = 3600;
     my $block = '([a-z0-9]{4})';
-    my $regexp = quotemeta($zone->resolves_to);
+    my $regexp = quotemeta(lc($zone->resolves_to));
     my ($address, $mask) = ($zone->network =~ m,^([^/]+)/([0-9]+),);
     my @components = unpack("n8", ipv6_aton($address));
 
     my $numdigits = (128 - $mask) / 4;
     $regexp =~ s/\\%DIGITS\\%/([a-z0-9]{$numdigits})/i;
-    my ($digits) = ($qname =~ /$regexp/);
+    my ($digits) = (lc($qname) =~ /$regexp/);
     return ('NXDOMAIN', undef, undef, undef) unless defined($digits);
 
     if ($qtype ne 'AAAA') {

--- a/lib/App/AllKnowingDNS/Handler.pm
+++ b/lib/App/AllKnowingDNS/Handler.pm
@@ -58,7 +58,7 @@ sub handle_ptr_query {
     my $ttl = 3600;
     my $fullname = $qname;
     substr($fullname, -1 * length($zone->ptrzone)) = '';
-    my $hostpart = join '', reverse split /\./, $fullname;
+    my $hostpart = join '', map { lc } reverse split /\./, $fullname;
     my $rdata = $zone->resolves_to;
     $rdata =~ s/%DIGITS%/$hostpart/i;
     my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");

--- a/t/004-handler.t
+++ b/t/004-handler.t
@@ -40,6 +40,20 @@ is(scalar @$ans, 1, 'one answer RR');
 my ($rr) = @$ans;
 is($rr->type, 'PTR', 'RR type is PTR');
 is($rr->rdatastr, 'ipv6-0219dbfffe432ec7-blah.nutzer.raumzeitlabor.de.', 'RR ok');
+is($rr->owner, $qname, 'RR owner is original qname');
+
+################################################################################
+# Check resolving PTR records in randomized case with a config
+################################################################################
+
+$qname = '7.C.e.2.3.4.E.f.F.f.B.d.9.1.2.0.0.C.c.C.e.0.0.1.8.8.D.4.1.0.0.2.iP6.ArpA';
+($rcode, $ans, $auth, $add) = reply_handler($config, 0, $qname, $qclass, $qtype, $peerhost);
+is($rcode, 'NOERROR', 'no error when handling query');
+is(scalar @$ans, 1, 'one answer RR');
+($rr) = @$ans;
+is($rr->type, 'PTR', 'RR type is PTR');
+is($rr->rdatastr, 'ipv6-0219dbfffe432ec7-blah.nutzer.raumzeitlabor.de.', 'RR ok');
+is($rr->owner, $qname, 'RR owner is original qname');
 
 ################################################################################
 # Check resolving hostnames to AAAA records
@@ -55,6 +69,23 @@ is(scalar @$ans, 1, 'one answer RR');
 ($rr) = @$ans;
 is($rr->type, 'AAAA', 'RR type is AAAA');
 is($rr->rdatastr, '2001:4d88:100e:ccc0:219:dbff:fe43:2ec7', 'RR ok');
+is($rr->owner, $qname, 'RR owner is original qname');
+
+################################################################################
+# Check resolving hostnames to AAAA records with randomized case
+################################################################################
+
+$qname = 'iPv6-0219dbfffe432ec7-BlAh.NuTzEr.RaUmZeItLaBoR.dE';
+$qclass = 'IN';
+$qtype = 'AAAA';
+$peerhost = 'testsuite';
+($rcode, $ans, $auth, $add) = reply_handler($config, 0, $qname, $qclass, $qtype, $peerhost);
+is($rcode, 'NOERROR', 'no error when handling query');
+is(scalar @$ans, 1, 'one answer RR');
+($rr) = @$ans;
+is($rr->type, 'AAAA', 'RR type is AAAA');
+is($rr->rdatastr, '2001:4d88:100e:ccc0:219:dbff:fe43:2ec7', 'RR ok');
+is($rr->owner, $qname, 'RR owner is original qname');
 
 ################################################################################
 # Check resolving hostnames to A records


### PR DESCRIPTION
This fixes forwarded DNS queries which are issued in mixed/randomized case (e.g. by Unbound).

I noticed that AllKnowingDNS seems to always return `NXDOMAIN` on queries from an Unbound server. I ran `all-knowning-dns --querylog` and it seems that Unbound redirects the queries in mixed/randomized case:

~~~
13.10.2019 23:37:14 +0200 - 2001:470:539f::4 - query for 5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.9.3.5.0.7.4.0.1.0.0.2.ip6.aRPa (PTR)
~~~

(see the `aRPa` at the end)

This is a technique to improve the transaction identity of DNS requests: https://tools.ietf.org/html/draft-vixie-dnsext-dns0x20-00

As DNS names must be case-insensitive, this PR changes the behavior of  the Handler to return matching AAAA/PTR records regardless of the case in the query. As pointed out by Googles Public DNS documentation (https://developers.google.com/speed/public-dns/docs/security?csw=1#randomize_case), it is important to keep the case exactly the same in the response which was also implemented here. 