### PR TITLE
all-knowing-dns: remove deprecated Net::DNS main_loop call

### DIFF
--- a/script/all-knowing-dns
+++ b/script/all-knowing-dns
@@ -69,10 +69,10 @@ my $ns = Net::DNS::Nameserver->new(
     NotifyHandler => sub { ('SERVFAIL', undef, undef, undef) },
     Verbose => 0);
 
-# Now that we are listening, drop privileges.
+# Drop privileges.
 drop_privileges('nobody');
 
-$ns->main_loop;
+$ns->start_server(0);
 
 __END__
 


### PR DESCRIPTION
After updating to Debian 13/trixie (and it's new Net::DNS version), all-knowing-dns stopped working with 
```
Can't locate object method "main_loop" via package "Net::DNS::Nameserver" at /usr/bin/all-knowing-dns line 75.
```

Net-DNS-1.48 and upwards have deprecated the "main_loop" call. Instead, users should call ->start_server() now, which internally spawns new subprocesses, which will then listen to the TCP/UDP ports.

As already mentioned in #4, this causes issues when not executed with CAP_NET_BIND_SERVICE.

Running all-knowing-dns using

```
[Service]
User=nobody
Group=nogroup
AmbientCapabilities=CAP_NET_BIND_SERVICE
```

as user "nobody" directly (but with privileged binding capabilities) should be a bit safer and still works with recent Net-DNS versions.

What's the best way forward here? The .service file isn't being provided by you (as far as I can tell), so I guess this pull request should be merged and then I should talk to the distro maintainers to get the .service file updated? 